### PR TITLE
3.22.x backport nullable plugin

### DIFF
--- a/src/google/protobuf/compiler/csharp/csharp_field_base.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_field_base.cc
@@ -93,6 +93,7 @@ void FieldGeneratorBase::SetCommonFieldVariables(
 
   (*variables)["property_name"] = property_name();
   (*variables)["type_name"] = type_name();
+  (*variables)["containing_type_full_name"] = descriptor_->containing_type()->full_name();
   (*variables)["extended_type"] = GetClassName(descriptor_->containing_type());
   (*variables)["name"] = name();
   (*variables)["descriptor_name"] = descriptor_->name();

--- a/src/google/protobuf/compiler/csharp/csharp_message.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_message.cc
@@ -269,6 +269,8 @@ void MessageGenerator::Generate(io::Printer* printer) {
       "}\n\n");
   }
 
+  // class scope insertion point for setEmpty / setNull methods on repeated fields
+  printer->Print("// @@protoc_insertion_point(class_scope:$full_name$)\n", "full_name", descriptor_->full_name());
   // Standard methods
   GenerateFrameworkMethods(printer);
   GenerateMessageSerializationMethods(printer);

--- a/src/google/protobuf/compiler/csharp/csharp_primitive_field.cc
+++ b/src/google/protobuf/compiler/csharp/csharp_primitive_field.cc
@@ -143,6 +143,9 @@ void PrimitiveFieldGenerator::GenerateMembers(io::Printer* printer) {
       "    $name$_ = pb::ProtoPreconditions.CheckNotNull(value, \"value\");\n");
   }
   printer->Print(
+    variables_,
+    "    // @@protoc_insertion_point(message_field_modifier_scope:$containing_type_full_name$.set$property_name$)\n");
+  printer->Print(
     "  }\n"
     "}\n");
 

--- a/src/google/protobuf/compiler/java/enum_field.cc
+++ b/src/google/protobuf/compiler/java/enum_field.cc
@@ -821,6 +821,7 @@ void RepeatedImmutableEnumFieldGenerator::GenerateBuilderMembers(
                  "  ensure$capitalized_name$IsMutable();\n"
                  "  $name$_.add(value.getNumber());\n"
                  "  onChanged();\n"
+                 "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.add$capitalized_name$)\n"
                  "  return this;\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -834,6 +835,7 @@ void RepeatedImmutableEnumFieldGenerator::GenerateBuilderMembers(
                  "    $name$_.add(value.getNumber());\n"
                  "  }\n"
                  "  onChanged();\n"
+                 "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.addAll$capitalized_name$)\n"
                  "  return this;\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -845,6 +847,7 @@ void RepeatedImmutableEnumFieldGenerator::GenerateBuilderMembers(
       "  $name$_ = java.util.Collections.emptyList();\n"
       "  $clear_mutable_bit_builder$;\n"
       "  onChanged();\n"
+      "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.clear$capitalized_name$)\n"
       "  return this;\n"
       "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -886,6 +889,7 @@ void RepeatedImmutableEnumFieldGenerator::GenerateBuilderMembers(
                    "  ensure$capitalized_name$IsMutable();\n"
                    "  $name$_.add(value);\n"
                    "  onChanged();\n"
+                   "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.add$capitalized_name$Value)\n"
                    "  return this;\n"
                    "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -900,6 +904,7 @@ void RepeatedImmutableEnumFieldGenerator::GenerateBuilderMembers(
         "    $name$_.add(value);\n"
         "  }\n"
         "  onChanged();\n"
+        "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.addAll$capitalized_name$Value)\n"
         "  return this;\n"
         "}\n");
     printer->Annotate("{", "}", descriptor_);

--- a/src/google/protobuf/compiler/java/enum_field.cc
+++ b/src/google/protobuf/compiler/java/enum_field.cc
@@ -184,6 +184,7 @@ void ImmutableEnumFieldGenerator::GenerateMembers(io::Printer* printer) const {
     printer->Print(variables_,
                    "@java.lang.Override $deprecation$public boolean "
                    "${$has$capitalized_name$$}$() {\n"
+                   "  // @@protoc_insertion_point(message_field_presence_checker_scope:$containing_type_full_name$.has$capitalized_name$)\n"
                    "  return $get_has_field_bit_message$;\n"
                    "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -215,6 +216,7 @@ void ImmutableEnumFieldGenerator::GenerateBuilderMembers(
     printer->Print(variables_,
                    "@java.lang.Override $deprecation$public boolean "
                    "${$has$capitalized_name$$}$() {\n"
+                   "  // @@protoc_insertion_point(builder_field_presence_checker_scope:$containing_type_full_name$.has$capitalized_name$)\n"
                    "  return $get_has_field_bit_builder$;\n"
                    "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -235,6 +237,7 @@ void ImmutableEnumFieldGenerator::GenerateBuilderMembers(
                    "  $name$_ = value;\n"
                    "  $set_has_field_bit_builder$\n"
                    "  onChanged();\n"
+                   "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.set$capitalized_name$Value)\n"
                    "  return this;\n"
                    "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -258,6 +261,7 @@ void ImmutableEnumFieldGenerator::GenerateBuilderMembers(
                  "  $set_has_field_bit_builder$\n"
                  "  $name$_ = value.getNumber();\n"
                  "  onChanged();\n"
+                 "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.set$capitalized_name$)\n"
                  "  return this;\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -269,6 +273,7 @@ void ImmutableEnumFieldGenerator::GenerateBuilderMembers(
       "  $clear_has_field_bit_builder$\n"
       "  $name$_ = $default_number$;\n"
       "  onChanged();\n"
+      "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.clear$capitalized_name$)\n"
       "  return this;\n"
       "}\n");
   printer->Annotate("{", "}", descriptor_);

--- a/src/google/protobuf/compiler/java/field.cc
+++ b/src/google/protobuf/compiler/java/field.cc
@@ -247,6 +247,7 @@ void SetCommonFieldVariables(
     absl::flat_hash_map<absl::string_view, std::string>* variables) {
   (*variables)["field_name"] = descriptor->name();
   (*variables)["name"] = info->name;
+  (*variables)["containing_type_full_name"] = descriptor->containing_type()->full_name();
   (*variables)["classname"] = descriptor->containing_type()->name();
   (*variables)["capitalized_name"] = info->capitalized_name;
   (*variables)["disambiguated_reason"] = info->disambiguated_reason;

--- a/src/google/protobuf/compiler/java/map_field.cc
+++ b/src/google/protobuf/compiler/java/map_field.cc
@@ -419,6 +419,7 @@ void ImmutableMapFieldGenerator::GenerateBuilderMembers(
       "  $clear_has_field_bit_builder$\n"
       "  internalGetMutable$capitalized_name$().getMutableMap()\n"
       "      .clear();\n"
+      "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.clear$capitalized_name$)\n"
       "  return this;\n"
       "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -430,6 +431,7 @@ void ImmutableMapFieldGenerator::GenerateBuilderMembers(
                  "  $key_null_check$\n"
                  "  internalGetMutable$capitalized_name$().getMutableMap()\n"
                  "      .remove(key);\n"
+                 "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.remove$capitalized_name$)\n"
                  "  return this;\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -461,6 +463,7 @@ void ImmutableMapFieldGenerator::GenerateBuilderMembers(
                    "  internalGetMutable$capitalized_name$().getMutableMap()\n"
                    "      .put(key, $name$ValueConverter.doBackward(value));\n"
                    "  $set_has_field_bit_builder$\n"
+                   "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.put$capitalized_name$)\n"
                    "  return this;\n"
                    "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -474,6 +477,7 @@ void ImmutableMapFieldGenerator::GenerateBuilderMembers(
         "      internalGetMutable$capitalized_name$().getMutableMap())\n"
         "          .putAll(values);\n"
         "  $set_has_field_bit_builder$\n"
+        "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.putAll$capitalized_name$)\n"
         "  return this;\n"
         "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -505,6 +509,7 @@ void ImmutableMapFieldGenerator::GenerateBuilderMembers(
           "  internalGetMutable$capitalized_name$().getMutableMap()\n"
           "      .put(key, value);\n"
           "  $set_has_field_bit_builder$\n"
+          "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.put$capitalized_name$Value)\n"
           "  return this;\n"
           "}\n");
       printer->Annotate("{", "}", descriptor_);
@@ -517,6 +522,7 @@ void ImmutableMapFieldGenerator::GenerateBuilderMembers(
           "  internalGetMutable$capitalized_name$().getMutableMap()\n"
           "      .putAll(values);\n"
           "  $set_has_field_bit_builder$\n"
+          "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.putAll$capitalized_name$Value)\n"
           "  return this;\n"
           "}\n");
       printer->Annotate("{", "}", descriptor_);
@@ -547,6 +553,7 @@ void ImmutableMapFieldGenerator::GenerateBuilderMembers(
                    "  internalGetMutable$capitalized_name$().getMutableMap()\n"
                    "      .put(key, value);\n"
                    "  $set_has_field_bit_builder$\n"
+                   "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.put$capitalized_name$)\n"
                    "  return this;\n"
                    "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -559,6 +566,7 @@ void ImmutableMapFieldGenerator::GenerateBuilderMembers(
         "  internalGetMutable$capitalized_name$().getMutableMap()\n"
         "      .putAll(values);\n"
         "  $set_has_field_bit_builder$\n"
+        "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.putAll$capitalized_name$)\n"
         "  return this;\n"
         "}\n");
     printer->Annotate("{", "}", descriptor_);

--- a/src/google/protobuf/compiler/java/message_field.cc
+++ b/src/google/protobuf/compiler/java/message_field.cc
@@ -1041,6 +1041,7 @@ void RepeatedImmutableMessageFieldGenerator::GenerateBuilderMembers(
 
       "$name$Builder_.addMessage(value);\n",
 
+      "// @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.add$capitalized_name$)\n"
       "return this;\n");
 
   // Builder addRepeatedField(int index, Field value)
@@ -1059,6 +1060,7 @@ void RepeatedImmutableMessageFieldGenerator::GenerateBuilderMembers(
 
       "$name$Builder_.addMessage(index, value);\n",
 
+      "// @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.addIndex$capitalized_name$)\n"
       "return this;\n");
 
   // Builder addRepeatedField(Field.Builder builderForValue)
@@ -1074,6 +1076,7 @@ void RepeatedImmutableMessageFieldGenerator::GenerateBuilderMembers(
 
       "$name$Builder_.addMessage(builderForValue.build());\n",
 
+      "// @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.add$capitalized_name$Builder)\n"
       "return this;\n");
 
   // Builder addRepeatedField(int index, Field.Builder builderForValue)
@@ -1089,6 +1092,7 @@ void RepeatedImmutableMessageFieldGenerator::GenerateBuilderMembers(
 
       "$name$Builder_.addMessage(index, builderForValue.build());\n",
 
+      "// @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.addIndex$capitalized_name$Builder)\n"
       "return this;\n");
 
   // Builder addAllRepeatedField(Iterable<Field> values)
@@ -1105,6 +1109,7 @@ void RepeatedImmutableMessageFieldGenerator::GenerateBuilderMembers(
 
       "$name$Builder_.addAllMessages(values);\n",
 
+      "// @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.addAll$capitalized_name$)\n"
       "return this;\n");
 
   // Builder clearRepeatedField()
@@ -1118,6 +1123,7 @@ void RepeatedImmutableMessageFieldGenerator::GenerateBuilderMembers(
 
       "$name$Builder_.clear();\n",
 
+      "// @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.clear$capitalized_name$)\n"
       "return this;\n");
 
   // Builder removeRepeatedField(int index)
@@ -1132,6 +1138,7 @@ void RepeatedImmutableMessageFieldGenerator::GenerateBuilderMembers(
 
       "$name$Builder_.remove(index);\n",
 
+      "// @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.removeIndex$capitalized_name$)\n"
       "return this;\n");
 
   // Field.Builder getRepeatedFieldBuilder(int index)
@@ -1177,6 +1184,7 @@ void RepeatedImmutableMessageFieldGenerator::GenerateBuilderMembers(
   printer->Print(variables_,
                  "$deprecation$public $type$.Builder "
                  "${$add$capitalized_name$Builder$}$() {\n"
+                 "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.add$capitalized_name$DefaultBuilder)\n"
                  "  return get$capitalized_name$FieldBuilder().addBuilder(\n"
                  "      $type$.getDefaultInstance());\n"
                  "}\n");
@@ -1188,6 +1196,7 @@ void RepeatedImmutableMessageFieldGenerator::GenerateBuilderMembers(
       variables_,
       "$deprecation$public $type$.Builder ${$add$capitalized_name$Builder$}$(\n"
       "    int index) {\n"
+      "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.addIndex$capitalized_name$DefaultBuilder)\n"
       "  return get$capitalized_name$FieldBuilder().addBuilder(\n"
       "      index, $type$.getDefaultInstance());\n"
       "}\n");

--- a/src/google/protobuf/compiler/java/primitive_field.cc
+++ b/src/google/protobuf/compiler/java/primitive_field.cc
@@ -798,6 +798,7 @@ void RepeatedImmutablePrimitiveFieldGenerator::GenerateBuilderMembers(
                  "  ensure$capitalized_name$IsMutable();\n"
                  "  $repeated_add$(value);\n"
                  "  $on_changed$\n"
+                 "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.add$capitalized_name$)\n"
                  "  return this;\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -810,6 +811,7 @@ void RepeatedImmutablePrimitiveFieldGenerator::GenerateBuilderMembers(
                  "  com.google.protobuf.AbstractMessageLite.Builder.addAll(\n"
                  "      values, $name$_);\n"
                  "  $on_changed$\n"
+                 "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.addAll$capitalized_name$)\n"
                  "  return this;\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -821,6 +823,7 @@ void RepeatedImmutablePrimitiveFieldGenerator::GenerateBuilderMembers(
       "  $name$_ = $empty_list$;\n"
       "  $clear_mutable_bit_builder$;\n"
       "  $on_changed$\n"
+      "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.clear$capitalized_name$)\n"
       "  return this;\n"
       "}\n");
   printer->Annotate("{", "}", descriptor_);

--- a/src/google/protobuf/compiler/java/primitive_field.cc
+++ b/src/google/protobuf/compiler/java/primitive_field.cc
@@ -240,6 +240,7 @@ void ImmutablePrimitiveFieldGenerator::GenerateMembers(
         variables_,
         "@java.lang.Override\n"
         "$deprecation$public boolean ${$has$capitalized_name$$}$() {\n"
+        "  // @@protoc_insertion_point(message_field_presence_checker_scope:$containing_type_full_name$.has$capitalized_name$)\n"
         "  return $get_has_field_bit_message$;\n"
         "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -264,6 +265,7 @@ void ImmutablePrimitiveFieldGenerator::GenerateBuilderMembers(
         variables_,
         "@java.lang.Override\n"
         "$deprecation$public boolean ${$has$capitalized_name$$}$() {\n"
+        "  // @@protoc_insertion_point(builder_field_presence_checker_scope:$containing_type_full_name$.has$capitalized_name$)\n"
         "  return $get_has_field_bit_builder$;\n"
         "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -286,6 +288,7 @@ void ImmutablePrimitiveFieldGenerator::GenerateBuilderMembers(
                  "  $name$_ = value;\n"
                  "  $set_has_field_bit_builder$\n"
                  "  $on_changed$\n"
+                 "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.set$capitalized_name$)\n"
                  "  return this;\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -309,6 +312,7 @@ void ImmutablePrimitiveFieldGenerator::GenerateBuilderMembers(
   }
   printer->Print(variables_,
                  "  $on_changed$\n"
+                 "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.clear$capitalized_name$)\n"
                  "  return this;\n"
                  "}\n");
 }

--- a/src/google/protobuf/compiler/java/string_field.cc
+++ b/src/google/protobuf/compiler/java/string_field.cc
@@ -224,6 +224,7 @@ void ImmutableStringFieldGenerator::GenerateMembers(
         variables_,
         "@java.lang.Override\n"
         "$deprecation$public boolean ${$has$capitalized_name$$}$() {\n"
+        "  // @@protoc_insertion_point(message_field_presence_checker_scope:$containing_type_full_name$.has$capitalized_name$)\n"
         "  return $get_has_field_bit_message$;\n"
         "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -282,6 +283,7 @@ void ImmutableStringFieldGenerator::GenerateBuilderMembers(
     printer->Print(
         variables_,
         "$deprecation$public boolean ${$has$capitalized_name$$}$() {\n"
+        "  // @@protoc_insertion_point(builder_field_presence_checker_scope:$containing_type_full_name$.has$capitalized_name$)\n"
         "  return $get_has_field_bit_builder$;\n"
         "}\n");
     printer->Annotate("{", "}", descriptor_);
@@ -338,6 +340,7 @@ void ImmutableStringFieldGenerator::GenerateBuilderMembers(
                  "  $name$_ = value;\n"
                  "  $set_has_field_bit_builder$\n"
                  "  $on_changed$\n"
+                 "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.set$capitalized_name$)\n"
                  "  return this;\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -354,6 +357,7 @@ void ImmutableStringFieldGenerator::GenerateBuilderMembers(
   printer->Print(variables_,
                  "  $clear_has_field_bit_builder$\n"
                  "  $on_changed$\n"
+                 "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.clear$capitalized_name$)\n"
                  "  return this;\n"
                  "}\n");
 
@@ -372,6 +376,7 @@ void ImmutableStringFieldGenerator::GenerateBuilderMembers(
                  "  $name$_ = value;\n"
                  "  $set_has_field_bit_builder$\n"
                  "  $on_changed$\n"
+                 "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.set$capitalized_name$Bytes)\n"
                  "  return this;\n"
                  "}\n");
 }

--- a/src/google/protobuf/compiler/java/string_field.cc
+++ b/src/google/protobuf/compiler/java/string_field.cc
@@ -910,6 +910,7 @@ void RepeatedImmutableStringFieldGenerator::GenerateBuilderMembers(
                  "  $name$_.add(value);\n"
                  "  $set_has_field_bit_builder$\n"
                  "  $on_changed$\n"
+                 "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.add$capitalized_name$)\n"
                  "  return this;\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -923,6 +924,7 @@ void RepeatedImmutableStringFieldGenerator::GenerateBuilderMembers(
                  "      values, $name$_);\n"
                  "  $set_has_field_bit_builder$\n"
                  "  $on_changed$\n"
+                 "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.addAll$capitalized_name$)\n"
                  "  return this;\n"
                  "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -935,6 +937,7 @@ void RepeatedImmutableStringFieldGenerator::GenerateBuilderMembers(
       "    $empty_list$;\n"
       "  $clear_has_field_bit_builder$;\n"
       "  $on_changed$\n"
+      "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.clear$capitalized_name$)\n"
       "  return this;\n"
       "}\n");
   printer->Annotate("{", "}", descriptor_);
@@ -955,6 +958,7 @@ void RepeatedImmutableStringFieldGenerator::GenerateBuilderMembers(
                  "  $name$_.add(value);\n"
                  "  $set_has_field_bit_builder$\n"
                  "  $on_changed$\n"
+                 "  // @@protoc_insertion_point(builder_field_modifier_scope:$containing_type_full_name$.add$capitalized_name$Bytes)\n"
                  "  return this;\n"
                  "}\n");
 }


### PR DESCRIPTION
Reimplement Java and C# insertion points (for `nullable` usage) in 3.22.x branch.