### PR TITLE
3.22.x backport java lib patch

### DIFF
--- a/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
+++ b/java/core/src/main/java/com/google/protobuf/GeneratedMessageV3.java
@@ -2410,6 +2410,7 @@ public abstract class GeneratedMessageV3 extends AbstractMessage implements Seri
         hasHasMethod =
             descriptor.getFile().getSyntax() == FileDescriptor.Syntax.PROTO2
                 || descriptor.hasOptionalKeyword()
+                || existsMethod(messageClass, "has" + camelCaseName)
                 || (!isOneofField && descriptor.getJavaType() == FieldDescriptor.JavaType.MESSAGE);
         ReflectionInvoker reflectionInvoker =
             new ReflectionInvoker(
@@ -3366,6 +3367,15 @@ public abstract class GeneratedMessageV3 extends AbstractMessage implements Seri
               .setKey(entry.getKey())
               .setValue(entry.getValue())
               .build());
+    }
+  }
+
+  private static boolean existsMethod(Class msgClass, String methodName, Class... parameterTypes) {
+    try {
+      msgClass.getMethod(methodName, parameterTypes);
+      return true;
+    } catch (NoSuchMethodException e) {
+      return false;
     }
   }
 }


### PR DESCRIPTION
This patch aims to be able to use protobuf reflection to get a scalar field consistently regarding to whether it's set.
(But probabaly we don't need it, it does not harm, anyway) 