### PR TITLE
GithubActions: Criteo Release Workflow

### DIFF
--- a/.github/workflows/criteo_release.yml
+++ b/.github/workflows/criteo_release.yml
@@ -52,6 +52,15 @@ jobs:
     - name: Checkout submodule
       run: git submodule update --init --recursive
 
+    - name: Set protoc version for Unix
+      if: ${{ matrix.os_family == 'linux' || matrix.os_family == 'osx' }}
+      run: sed -i.bak 's/4\.22\.5/${{ env.proto_version }}/g' CMakeLists.txt
+
+    - name: Set protoc version for Windows
+      if: ${{ matrix.os == 'windows-latest' }}
+      run: >
+        (Get-Content CMakeLists.txt) -replace '4.22.5', '${{ env.proto_version }}' | Set-Content CMakeLists.txt
+
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type

--- a/.github/workflows/criteo_release.yml
+++ b/.github/workflows/criteo_release.yml
@@ -1,0 +1,111 @@
+name: Criteo Release Workflow
+run-name: Release ${{github.ref_name}}
+
+on:
+  push:
+    tags: ['v*-criteo']
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        build_type: [Release]
+        include:
+          - os: ubuntu-latest
+            os_family: linux
+            arch: x86_64
+          # macos-latest image is arm64 based
+          - os: macos-latest
+            os_family: osx
+            arch: aarch_64
+          # macos-13 image is the most recent x86 based macos
+          - os: macos-13
+            os_family: osx
+            arch: x86_64
+          - os: windows-latest
+            os_family: windows
+            arch: x86_64
+
+    steps:
+    - name: Parse version for Unix
+      if: ${{ matrix.os_family == 'linux' || matrix.os_family == 'osx' }}
+      # Strip 'v' prefix of the tag
+      run: |
+        proto_tag="${{ github.ref_name }}"
+        echo "proto_version=${proto_tag#v}" >> "$GITHUB_ENV"
+
+    - name: Parse version for Windows
+      if: ${{ matrix.os_family == 'windows' }}
+      # Strip 'v' prefix of the tag, noting that windows env variable is namespaced with `env:`
+      run: |
+        $proto_tag = "${{ github.ref_name }}"
+        $proto_version = $proto_tag.TrimStart("v")
+        echo "proto_version=$proto_version" >> "$env:GITHUB_ENV"
+
+    - name: Checkout Protobuf
+      uses: actions/checkout@v4
+
+    - name: Checkout submodule
+      run: git submodule update --init --recursive
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: >
+        cmake -B ${{ github.workspace }}/build
+        -G "Unix Makefiles"
+        -DCMAKE_CXX_STANDARD=14
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+
+    - name: Build protoc
+      run: cmake --build ${{ github.workspace }}/build
+
+    - name: Rename protoc for Unix
+      if: ${{ matrix.os_family == 'linux' || matrix.os_family == 'osx' }}
+      run: >
+        mv $(readlink -f ${{ github.workspace }}/build/protoc)
+        ${{ github.workspace }}/build/protoc-${{ env.proto_version }}-${{ matrix.os_family }}-${{ matrix.arch }}.exe
+
+    - name: Rename protoc for Windows
+      if: ${{ matrix.os_family == 'windows' }}
+      run: >
+        mv ${{ github.workspace }}/build/protoc.exe
+        ${{ github.workspace }}/build/protoc-${{ env.proto_version }}-${{ matrix.os_family }}-${{ matrix.arch }}.exe
+
+    - name: Publish protoc
+      uses: softprops/action-gh-release@v2.0.8
+      with:
+        files: |
+          ${{ github.workspace }}/build/protoc-${{ env.proto_version }}-${{ matrix.os_family }}-${{ matrix.arch }}.exe
+
+    - name: Setup Java JDK
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      uses: actions/setup-java@v4.2.2
+      with:
+        java-version: 8
+        distribution: temurin
+
+    - name: Build Java lib
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
+        ln -sfn ${{ github.workspace }}/build/protoc-${{ env.proto_version }}-${{ matrix.os_family }}-${{ matrix.arch }}.exe ${{ github.workspace }}/protoc
+        cd ${{ github.workspace }}/java
+        mvn versions:set -DnewVersion="${{ env.proto_version }}" -DprocessAllModules=true
+        mvn package -pl core -am -DskipTests
+        mvn source:jar -pl core
+        cp pom.xml ${{ github.workspace }}/build/protobuf-parent.${{ env.proto_version }}.pom
+        cp core/pom.xml ${{ github.workspace }}/build/protobuf-java.${{ env.proto_version }}.pom
+        mv core/target/protobuf*.jar ${{ github.workspace }}/build/
+
+    - name: Publish Java lib
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      uses: softprops/action-gh-release@v2.0.8
+      with:
+        files: |
+          ${{ github.workspace }}/build/protobuf-*.pom
+          ${{ github.workspace }}/build/protobuf-*.jar
+

--- a/.github/workflows/criteo_release.yml
+++ b/.github/workflows/criteo_release.yml
@@ -31,90 +31,90 @@ jobs:
             arch: x86_64
 
     steps:
-    - name: Parse version for Unix
-      if: ${{ matrix.os_family == 'linux' || matrix.os_family == 'osx' }}
-      # Strip 'v' prefix of the tag
-      run: |
-        proto_tag="${{ github.ref_name }}"
-        echo "proto_version=${proto_tag#v}" >> "$GITHUB_ENV"
+      - name: Parse version for Unix
+        if: ${{ matrix.os_family == 'linux' || matrix.os_family == 'osx' }}
+        # Strip 'v' prefix of the tag
+        run: |
+          proto_tag="${{ github.ref_name }}"
+          echo "proto_version=${proto_tag#v}" >> "$GITHUB_ENV"
 
-    - name: Parse version for Windows
-      if: ${{ matrix.os_family == 'windows' }}
-      # Strip 'v' prefix of the tag, noting that windows env variable is namespaced with `env:`
-      run: |
-        $proto_tag = "${{ github.ref_name }}"
-        $proto_version = $proto_tag.TrimStart("v")
-        echo "proto_version=$proto_version" >> "$env:GITHUB_ENV"
+      - name: Parse version for Windows
+        if: ${{ matrix.os_family == 'windows' }}
+        # Strip 'v' prefix of the tag, noting that windows env variable is namespaced with `env:`
+        run: |
+          $proto_tag = "${{ github.ref_name }}"
+          $proto_version = $proto_tag.TrimStart("v")
+          echo "proto_version=$proto_version" >> "$env:GITHUB_ENV"
 
-    - name: Checkout Protobuf
-      uses: actions/checkout@v4
+      - name: Checkout Protobuf
+        uses: actions/checkout@v4
 
-    - name: Checkout submodule
-      run: git submodule update --init --recursive
+      - name: Checkout submodule
+        run: git submodule update --init --recursive
 
-    - name: Set protoc version for Unix
-      if: ${{ matrix.os_family == 'linux' || matrix.os_family == 'osx' }}
-      run: sed -i.bak 's/4\.22\.5/${{ env.proto_version }}/g' CMakeLists.txt
+      - name: Set protoc version for Unix
+        if: ${{ matrix.os_family == 'linux' || matrix.os_family == 'osx' }}
+        run: sed -i.bak 's/4\.22\.5/${{ env.proto_version }}/g' CMakeLists.txt
 
-    - name: Set protoc version for Windows
-      if: ${{ matrix.os == 'windows-latest' }}
-      run: >
-        (Get-Content CMakeLists.txt) -replace '4.22.5', '${{ env.proto_version }}' | Set-Content CMakeLists.txt
+      - name: Set protoc version for Windows
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: >
+          (Get-Content CMakeLists.txt) -replace '4.22.5', '${{ env.proto_version }}' | Set-Content CMakeLists.txt
 
-    - name: Configure CMake
-      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
-      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: >
-        cmake -B ${{ github.workspace }}/build
-        -G "Unix Makefiles"
-        -DCMAKE_CXX_STANDARD=14
-        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+      - name: Configure CMake
+        # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+        # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+        run: >
+          cmake -B ${{ github.workspace }}/build
+          -G "Unix Makefiles"
+          -DCMAKE_CXX_STANDARD=14
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
 
-    - name: Build protoc
-      run: cmake --build ${{ github.workspace }}/build
+      - name: Build protoc
+        run: cmake --build ${{ github.workspace }}/build
 
-    - name: Rename protoc for Unix
-      if: ${{ matrix.os_family == 'linux' || matrix.os_family == 'osx' }}
-      run: >
-        mv $(readlink -f ${{ github.workspace }}/build/protoc)
-        ${{ github.workspace }}/build/protoc-${{ env.proto_version }}-${{ matrix.os_family }}-${{ matrix.arch }}.exe
-
-    - name: Rename protoc for Windows
-      if: ${{ matrix.os_family == 'windows' }}
-      run: >
-        mv ${{ github.workspace }}/build/protoc.exe
-        ${{ github.workspace }}/build/protoc-${{ env.proto_version }}-${{ matrix.os_family }}-${{ matrix.arch }}.exe
-
-    - name: Publish protoc
-      uses: softprops/action-gh-release@v2.0.8
-      with:
-        files: |
+      - name: Rename protoc for Unix
+        if: ${{ matrix.os_family == 'linux' || matrix.os_family == 'osx' }}
+        run: >
+          mv $(readlink -f ${{ github.workspace }}/build/protoc)
           ${{ github.workspace }}/build/protoc-${{ env.proto_version }}-${{ matrix.os_family }}-${{ matrix.arch }}.exe
 
-    - name: Setup Java JDK
-      if: ${{ matrix.os == 'ubuntu-latest' }}
-      uses: actions/setup-java@v4.2.2
-      with:
-        java-version: 8
-        distribution: temurin
+      - name: Rename protoc for Windows
+        if: ${{ matrix.os_family == 'windows' }}
+        run: >
+          mv ${{ github.workspace }}/build/protoc.exe
+          ${{ github.workspace }}/build/protoc-${{ env.proto_version }}-${{ matrix.os_family }}-${{ matrix.arch }}.exe
 
-    - name: Build Java lib
-      if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: |
-        ln -sfn ${{ github.workspace }}/build/protoc-${{ env.proto_version }}-${{ matrix.os_family }}-${{ matrix.arch }}.exe ${{ github.workspace }}/protoc
-        cd ${{ github.workspace }}/java
-        mvn versions:set -DnewVersion="${{ env.proto_version }}" -DprocessAllModules=true
-        mvn package -pl core -am -DskipTests
-        mvn source:jar -pl core
-        cp pom.xml ${{ github.workspace }}/build/protobuf-parent.${{ env.proto_version }}.pom
-        cp core/pom.xml ${{ github.workspace }}/build/protobuf-java.${{ env.proto_version }}.pom
-        mv core/target/protobuf*.jar ${{ github.workspace }}/build/
+      - name: Publish protoc
+        uses: softprops/action-gh-release@v2.0.8
+        with:
+          files: |
+            ${{ github.workspace }}/build/protoc-${{ env.proto_version }}-${{ matrix.os_family }}-${{ matrix.arch }}.exe
 
-    - name: Publish Java lib
-      if: ${{ matrix.os == 'ubuntu-latest' }}
-      uses: softprops/action-gh-release@v2.0.8
-      with:
-        files: |
-          ${{ github.workspace }}/build/protobuf-*.pom
-          ${{ github.workspace }}/build/protobuf-*.jar
+      - name: Setup Java JDK
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: actions/setup-java@v4.2.2
+        with:
+          java-version: 8
+          distribution: temurin
+
+      - name: Build Java lib
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: |
+          ln -sfn ${{ github.workspace }}/build/protoc-${{ env.proto_version }}-${{ matrix.os_family }}-${{ matrix.arch }}.exe ${{ github.workspace }}/protoc
+          cd ${{ github.workspace }}/java
+          mvn versions:set -DnewVersion="${{ env.proto_version }}" -DprocessAllModules=true
+          mvn package -pl core -am -DskipTests
+          mvn source:jar -pl core
+          cp pom.xml ${{ github.workspace }}/build/protobuf-parent.${{ env.proto_version }}.pom
+          cp core/pom.xml ${{ github.workspace }}/build/protobuf-java.${{ env.proto_version }}.pom
+          mv core/target/protobuf*.jar ${{ github.workspace }}/build/
+
+      - name: Publish Java lib
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: softprops/action-gh-release@v2.0.8
+        with:
+          files: |
+            ${{ github.workspace }}/build/protobuf-*.pom
+            ${{ github.workspace }}/build/protobuf-*.jar
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ if (NOT protobuf_BUILD_PROTOBUF_BINARIES)
   set(protobuf_INSTALL OFF)
 endif()
 # Parse version tweaks
-set(protobuf_VERSION_REGEX "^([0-9]+)\\.([0-9]+)\\.([0-9]+)([-]rc[-]|\\.)?([0-9]*)$")
+set(protobuf_VERSION_REGEX "^([0-9]+)\\.([0-9]+)\\.([0-9]+)([-]rc[-]|\\.)?([0-9]*)(-criteo)$")
 string(REGEX REPLACE     "${protobuf_VERSION_REGEX}" "\\1"
   protobuf_VERSION_MAJOR "${protobuf_VERSION_STRING}")
 string(REGEX REPLACE     "${protobuf_VERSION_REGEX}" "\\2"
@@ -125,6 +125,8 @@ string(REGEX REPLACE     "${protobuf_VERSION_REGEX}" "\\3"
   protobuf_VERSION_PATCH "${protobuf_VERSION_STRING}")
 string(REGEX REPLACE     "${protobuf_VERSION_REGEX}" "\\5"
   protobuf_VERSION_PRERELEASE "${protobuf_VERSION_STRING}")
+string(REGEX REPLACE     "${protobuf_VERSION_REGEX}" "\\6"
+  protobuf_VERSION_CRITEO "${protobuf_VERSION_STRING}")
 
 message(STATUS "${protobuf_VERSION_PRERELEASE}")
 
@@ -137,6 +139,11 @@ if(protobuf_VERSION_PRERELEASE)
 else()
   set(protobuf_VERSION "${protobuf_VERSION}.0")
 endif()
+
+if(protobuf_VERSION_CRITEO)
+  set(protobuf_VERSION "${protobuf_VERSION}${protobuf_VERSION_CRITEO}")
+endif()
+
 message(STATUS "${protobuf_VERSION}")
 
 if(protobuf_VERBOSE)


### PR DESCRIPTION
Workflow will be triggered whenever a tag `v*-criteo` (eg. `v3.22.5-criteo`) is pushed. We can push a tag by creating a release on github repository.

It will publish protoc for:
- linux on x86_64
- osx on x86_64 and arm64
- windows on x86_64

It will also publish java library for protobuf-java library built with Java 8 (from ubuntu runner)