### PR TITLE
GithubActions: Improve Criteo Release Workflow

### DIFF
--- a/.github/workflows/criteo_release.yml
+++ b/.github/workflows/criteo_release.yml
@@ -5,8 +5,9 @@ on:
   push:
     tags: ['v*-criteo']
 
+
 jobs:
-  build:
+  build-release-assets:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -73,25 +74,22 @@ jobs:
       - name: Build protoc
         run: cmake --build ${{ github.workspace }}/build
 
+      - name: Create release artifacts directory for upload
+        run: mkdir ${{ github.workspace }}/build/release-artifacts
+
       - name: Rename protoc for Unix
         if: ${{ matrix.os_family == 'linux' || matrix.os_family == 'osx' }}
         run: >
           mv $(readlink -f ${{ github.workspace }}/build/protoc)
-          ${{ github.workspace }}/build/protoc-${{ env.proto_version }}-${{ matrix.os_family }}-${{ matrix.arch }}.exe
+          ${{ github.workspace }}/build/release-artifacts/protoc-${{ env.proto_version }}-${{ matrix.os_family }}-${{ matrix.arch }}.exe
 
       - name: Rename protoc for Windows
         if: ${{ matrix.os_family == 'windows' }}
         run: >
           mv ${{ github.workspace }}/build/protoc.exe
-          ${{ github.workspace }}/build/protoc-${{ env.proto_version }}-${{ matrix.os_family }}-${{ matrix.arch }}.exe
+          ${{ github.workspace }}/build/release-artifacts/protoc-${{ env.proto_version }}-${{ matrix.os_family }}-${{ matrix.arch }}.exe
 
-      - name: Publish protoc
-        uses: softprops/action-gh-release@v2.0.8
-        with:
-          files: |
-            ${{ github.workspace }}/build/protoc-${{ env.proto_version }}-${{ matrix.os_family }}-${{ matrix.arch }}.exe
-
-      - name: Setup Java JDK
+      - name: Setup JDK
         if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: actions/setup-java@v4.2.2
         with:
@@ -101,20 +99,52 @@ jobs:
       - name: Build Java lib
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: |
-          ln -sfn ${{ github.workspace }}/build/protoc-${{ env.proto_version }}-${{ matrix.os_family }}-${{ matrix.arch }}.exe ${{ github.workspace }}/protoc
+          ln -sfn ${{ github.workspace }}/build/release-artifacts/protoc-${{ env.proto_version }}-${{ matrix.os_family }}-${{ matrix.arch }}.exe ${{ github.workspace }}/protoc
           cd ${{ github.workspace }}/java
-          mvn versions:set -DnewVersion="${{ env.proto_version }}" -DprocessAllModules=true
+          mvn versions:set -DnewVersion=${{ env.proto_version }} -DprocessAllModules=true
           mvn package -pl core -am -DskipTests
           mvn source:jar -pl core
-          cp pom.xml ${{ github.workspace }}/build/protobuf-parent.${{ env.proto_version }}.pom
-          cp core/pom.xml ${{ github.workspace }}/build/protobuf-java.${{ env.proto_version }}.pom
-          mv core/target/protobuf*.jar ${{ github.workspace }}/build/
+          cp pom.xml ${{ github.workspace }}/build/release-artifacts/protobuf-parent.${{ env.proto_version }}.pom
+          cp core/pom.xml ${{ github.workspace }}/build/release-artifacts/protobuf-java.${{ env.proto_version }}.pom
+          cp protoc/pom.xml ${{ github.workspace }}/build/release-artifacts/protoc.${{ env.proto_version }}.pom
+          mv core/target/protobuf*.jar ${{ github.workspace }}/build/release-artifacts/
 
-      - name: Publish Java lib
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4.3.6
+        with:
+          name: artifacts-${{ env.proto_version }}-${{ matrix.os_family }}-${{ matrix.arch }}
+          path: ${{ github.workspace }}/build/release-artifacts
+          retention-days: 7
+
+
+  publish-release-assets:
+    needs: build-release-assets
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare environment
+        run: |
+          proto_tag="${{ github.ref_name }}"
+          proto_version=${proto_tag#v}
+          mkdir protobuf-dist-$proto_version
+          mkdir download
+          echo "proto_version=$proto_version" >> "$GITHUB_ENV"
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4.1.8
+        with:
+          pattern: artifacts-*
+          path: ${{ github.workspace }}/download
+
+      - name: Package artifacts
+        run: |
+          mv download/*/* protobuf-dist-${{ env.proto_version }}/
+          chmod +x protobuf-dist-${{ env.proto_version }}/protoc-*.exe
+          tar -czf protobuf-dist-${{ env.proto_version }}.tar.gz protobuf-dist-${{ env.proto_version }}
+
+      - name: Publish artifact
         uses: softprops/action-gh-release@v2.0.8
         with:
           files: |
-            ${{ github.workspace }}/build/protobuf-*.pom
-            ${{ github.workspace }}/build/protobuf-*.jar
+            protobuf-dist-${{ env.proto_version }}.tar.gz
+
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -282,6 +282,7 @@
     <module>util</module>
     <module>kotlin</module>
     <module>kotlin-lite</module>
+    <module>protoc</module>
   </modules>
 
 </project>


### PR DESCRIPTION
Package all artifacts into a tarball before publishing assets, so that we can download them all with one http request.
Use a second job to download all built artifacts to package them.