### PR TITLE
GithubActions: Fix pom file name in release

### DIFF
--- a/.github/workflows/criteo_release.yml
+++ b/.github/workflows/criteo_release.yml
@@ -104,9 +104,9 @@ jobs:
           mvn versions:set -DnewVersion=${{ env.proto_version }} -DprocessAllModules=true
           mvn package -pl core -am -DskipTests
           mvn source:jar -pl core
-          cp pom.xml ${{ github.workspace }}/build/release-artifacts/protobuf-parent.${{ env.proto_version }}.pom
-          cp core/pom.xml ${{ github.workspace }}/build/release-artifacts/protobuf-java.${{ env.proto_version }}.pom
-          cp protoc/pom.xml ${{ github.workspace }}/build/release-artifacts/protoc.${{ env.proto_version }}.pom
+          cp pom.xml ${{ github.workspace }}/build/release-artifacts/protobuf-parent-${{ env.proto_version }}.pom
+          cp core/pom.xml ${{ github.workspace }}/build/release-artifacts/protobuf-java-${{ env.proto_version }}.pom
+          cp protoc/pom.xml ${{ github.workspace }}/build/release-artifacts/protoc-${{ env.proto_version }}.pom
           mv core/target/protobuf*.jar ${{ github.workspace }}/build/release-artifacts/
 
       - name: Upload artifacts


### PR DESCRIPTION
The separator for version should be `-`.